### PR TITLE
Fix repository name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: upload dist/ folder as artifact
       uses: actions/upload-artifact@v1
       with:
-        name: frontend-explore
+        name: aiida-explorer
         path: dist/
 
 #  test:

--- a/README.md
+++ b/README.md
@@ -87,18 +87,18 @@ NPM, Grunt and Bower toolchain is used in order to automate the build process of
 Assuming these tools are already installed, one can build the **distribution** folder using:
 
 ```bash
-git clone git@github.com:materialscloud-org/frontend-explore.git
-cd frontend-explore
+git clone git@github.com:materialscloud-org/aiida-explorer.git
+cd aiida-explorer
 npm install && bower install
 grunt build
 ```
-This will build the **dist** folder inside the frontend-explore which can be deployed on the server.
+This will build the **dist** folder inside the aiida-explorer which can be deployed on the server.
 
 ## Deployment
 
 If you have received the **distribution** folder, you can run simple python web server as:
 ```bash
-cd frontend-explore/dist
+cd aiida-explorer/dist
 python -m http.server
 ```
 This will start simple http server from the directory which can be accessible at [http://localhost:8000](http://localhost:8000)

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "display-name": "Materials Cloud",
   "license": "MIT",
   "author": "Materials Cloud team <info@materialscloud.org>",
-  "repository": "https://github.com/materialscloud-org/frontend-explore.git",
+  "repository": "https://github.com/materialscloud-org/aiida-explorer.git",
   "dependencies": {
     "angular": "^1.6.5",
     "bootstrap": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "display-name": "Materials Cloud",
   "license": "MIT",
   "author": "Materials Cloud team <info@materialscloud.org>",
-  "repository": "https://github.com/materialscloud-org/frontend-explore.git",
+  "repository": "https://github.com/materialscloud-org/aiida-explorer.git",
   "dependencies": {
     "@angular/cdk": "^2.0.0-beta.11",
     "@angular/common": "^4.4.4",


### PR DESCRIPTION
Hi Materials Cloud!

Thanks for the great tool.

I found small issues with the repository name during cloning. I replaced an old name `frontend-explore` with the new one `aiida-explorer` in README.md and config files.

Could you please have a look when you have a free sec.

Thanks!